### PR TITLE
falcon: init: No longer force single-SIM for xt1033

### DIFF
--- a/init/init_falcon.cpp
+++ b/init/init_falcon.cpp
@@ -139,8 +139,10 @@ void init_msm_properties(unsigned long msm_id, unsigned long msm_ver, char *boar
             property_set("ro.build.fingerprint", "motorola/falcon_retbr_ds/falcon_umtsds:5.1/LPB23.13-56/58:user/release-keys");
             property_set("ro.build.product", "falcon_umtsds");
             property_set("ro.mot.build.customerid", "RETBR");
-            property_set("ro.telephony.default_network", "0");
-            property_set("persist.radio.multisim.config", "");
+            property_set("ro.telephony.default_network", "0,1");
+            property_set("persist.radio.multisim.config", "dsds");
+            property_set("persist.radio.dont_use_dsd", "true");
+            property_set("persist.radio.plmn_name_cmp", "1");
         }
     } else if (ISMATCH(radio, "0x6")) {
         /* xt1034 */


### PR DESCRIPTION
The RIL and dual-SIM have been (kinda) fixed, so we don't need to force single-SIM mode any longer.